### PR TITLE
Feature: Remaining OpenAI API Prompts Implemented

### DIFF
--- a/src/components/InputFields.tsx
+++ b/src/components/InputFields.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react';
 import ResultsGrid from './ResultGrid';
 
-const InputFields: React.FC = () => {
-    const [artist1, setArtist1] = useState('');
-    const [artist2, setArtist2] = useState('');
+interface InputFieldsProps {
+    activeTab: string;
+}
+
+const InputFields: React.FC<InputFieldsProps> = ({ activeTab }) => {
+    const [input1, setInput1] = useState('');
+    const [input2, setInput2] = useState('');
     const [songs, setSongs] = useState<{ song: string; artist: string }[]>([]);
     const [error, setError] = useState('');
 
@@ -13,7 +17,7 @@ const InputFields: React.FC = () => {
             const response = await fetch('/api/recommended-songs', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ artist1, artist2 }),
+                body: JSON.stringify({ type: activeTab, input1, input2 }),
             });
 
             if (!response.ok) {
@@ -57,16 +61,32 @@ const InputFields: React.FC = () => {
             <div className="flex space-x-4">
                 <input
                     type="text"
-                    value={artist1}
-                    onChange={e => setArtist1(e.target.value)}
-                    placeholder="Kanye West"
+                    value={input1}
+                    onChange={e => setInput1(e.target.value)}
+                    placeholder={
+                        activeTab === 'Artist to Artist'
+                        ? 'Artist 1'
+                        : activeTab === 'Song to Song'
+                        ? 'Song 1'
+                        : activeTab === 'Based on Mood'
+                        ? 'Mood 1 (e.g., Relaxing)'
+                        : 'Genre (e.g., Pop)'
+                    }
                     className="border rounded px-4 py-2 w-full max-w-xs"
                 />
                 <input
                     type="text"
-                    value={artist2}
-                    onChange={e => setArtist2(e.target.value)}
-                    placeholder="Taylor Swift"
+                    value={input2}
+                    onChange={e => setInput2(e.target.value)}
+                    placeholder={
+                        activeTab === 'Artist to Artist'
+                        ? 'Artist 2' 
+                        : activeTab === 'Song to Song'
+                        ? 'Song 2' 
+                        : activeTab === 'Based on Mood'
+                        ? 'Mood 2 (e.g., Stressed)' 
+                        : 'Instrument (e.g, violin)'
+                    }
                     className="border rounded px-4 py-2 w-full max-w-xs"
                 />
             </div>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -5,12 +5,18 @@ const tabOptions = [
     'Song to Song',
     'Based on Mood',
     'Genre | Instrument',
-    'Genre | BPM',
 ];
 
-const Tabs: React.FC = () => {
-    const [activeTab, setActiveTab] = useState(tabOptions[0]);
+interface TabsProps {
+    setActiveTab: (tab: string) => void;
+}
 
+const Tabs: React.FC<TabsProps> = ({ setActiveTab }) => {
+    const [activeTab, setTab] = useState(tabOptions[0]);
+    const handleTabClick = (tab: string) => {
+        setTab(tab);
+        setActiveTab(tab);
+    };
     return (
         <div className="flex justify-center space-x-2 overflow-auto">
             {tabOptions.map(tab => (
@@ -21,7 +27,7 @@ const Tabs: React.FC = () => {
                             ? 'bg-blue-500 text-white'
                             : 'bg-gray-200 text-gray-700'
                     }`}
-                    onClick={() => setActiveTab(tab)}
+                    onClick={() => handleTabClick(tab)}
                 >
                     {tab}
                 </button>

--- a/src/pages/api/recommended-songs.ts
+++ b/src/pages/api/recommended-songs.ts
@@ -13,29 +13,23 @@ export default async function handler(
         return res.status(405).json({ error: 'Method Not Allowed' });
     }
 
-    const { artist1, artist2 } = req.body;
+    const { type, input1, input2 } = req.body;
 
-    if (!artist1 || !artist2) {
-        return res
-            .status(400)
-            .json({ error: 'Both artist1 and artist2 are required.' });
+    if (!input1 || !input2) { 
+        return res.status(400).json({ error: 'Required inputs are missing.' }); // **CHANGED**
     }
+    let prompt = '';
 
-    try {
-        const response = await openai.chat.completions.create({
-            model: 'gpt-4',
-            messages: [
-                {
-                    role: 'user',
-                    content: `You are a music recommendation engine.
+    if (type === 'Artist to Artist') {
+        prompt = `You are a music recommendation engine.
                     I'll provide 2 artists potentially from different genres, your task is to generate a playlist connecting these artists through a progression of songs.
                     Each song in the playlist should represent a logical bridge between the styles of genres of the two artists.
                     The connection can be based on elements such as similar sounds, collaborations, influences, or any other meaningful link.
                     The first song must be artist 1, the last song should be artist 2 and you should bridge the gap.
                     Don't include an artist more than twice.
                     Based on the following two artists: 
-                    1. ${artist1}
-                    2. ${artist2}
+                    1. ${input1}
+                    2. ${input2}
                     
                     Provide 20 songs. 
                     
@@ -43,7 +37,57 @@ export default async function handler(
                     - The song's name
                     - The artist's name
                     
-                    Format the response as JSON with the following structure:
+                    `;
+    } 
+    else if (type === 'Song to Song') {
+        prompt = `You are a music recommendation engine.
+                    I'll provide 2 songs potentially from different genres, your task is to generate a playlist connecting these songs through a progression of songs.
+                    Each song in the playlist should represent a logical bridge between the styles of genres of the two artists.
+                    The connection can be based on elements such as similar sounds, collaborations, influences, or any other meaningful link.
+                    The first song must be song 1, the last song should be song 2 and you should bridge the gap.
+                    Don't include an artist more than twice.
+                    Based on the following two songs: 
+                    1. ${input1}
+                    2. ${input2}
+                    
+                    Provide 20 songs. 
+                    
+                    For each song, include:
+                    - The song's name
+                    - The artist's name
+                    
+                    `;
+    } 
+    else if (type === 'Based on Mood') {
+        prompt = `You are a music recommendation engine.
+                    I'll provide 2 moods, your task is to generate a playlist connecting these moods through a progression of songs.
+                    Each song in the playlist should represent a logical bridge between the two moods.
+                    The playlist should start with songs matching the mood "${input1}" and gradually transition to songs that represent the mood "${input2}". 
+                    Don't include an artist more than twice.
+                    Based on the following two moods: 
+                    1. ${input1}
+                    2. ${input2}
+                    
+                    Provide 20 songs. 
+                    
+                    For each song, include:
+                    - The song's name
+                    - The artist's name`;
+    }
+    else if (type === 'Genre | Instrument') {
+        prompt = `You are a music recommendation engine.
+                  Generate a playlist of 20 songs that belong to the "${input1}" genre and feature the "${input2}" instrument throughout the song.
+                  For each song, include:
+                  - The song's name
+                  - The artist's name.`;
+    }    
+    try {
+        const response = await openai.chat.completions.create({
+            model: 'gpt-3.5-turbo',
+            messages: [
+                {
+                    role: 'user',
+                    content: `${prompt}. Format the response as JSON with the following structure:
                     {
                         "playlist": [
                             {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Head from 'next/head';
 import Header from '../components/Header';
 import Tabs from '../components/Tabs';
@@ -6,18 +6,23 @@ import InputFields from '../components/InputFields';
 import ResultOptions from '../components/ResultOptions';
 import ResultGrid from '../components/ResultGrid';
 
-const Home: React.FC = () => (
-    <>
-        <Head>
-            <title>Playlist LLM</title>
-            <meta name="description" content="Generate playlists using AI" />
-        </Head>
-        <Header />
-        <Tabs />
-        <InputFields />
-        <ResultOptions />
-        <ResultGrid results={[]} />
-    </>
-);
-
+const Home: React.FC = () => {
+    const [activeTab, setActiveTab] = useState('Artist to Artist');
+    return (
+        <>
+            <Head>
+                <title>Playlist LLM</title>
+                <meta
+                    name="description"
+                    content="Generate playlists using AI"
+                />
+            </Head>
+            <Header />
+            <Tabs setActiveTab={setActiveTab} />
+            <InputFields activeTab={activeTab} />
+            <ResultOptions />
+            <ResultGrid results={[]} />
+        </>
+    );
+};
 export default Home;


### PR DESCRIPTION
# Feature: Remaining OpenAI API prompts Implemented

Added the different options of generation for Open AIs API: 
- song to song
- mood to mood
- genre with instrument
- BPM

## Mood:
- accepts a string of text that the user can enter and a playlist will be generated on it. 
![image](https://github.com/user-attachments/assets/0bd1c5df-0e48-49c1-a118-faa34d4215ac)

## Song to Song:
- Works similiarly to Artist to artist.
![image](https://github.com/user-attachments/assets/48eca5ad-8d3e-4932-9b6e-bae5d3f9a458)

## Prompt + Instrument:
- Works well with generic inputs.
![image](https://github.com/user-attachments/assets/68ae7e36-3a2b-4d1c-916f-846dfa464638)

## Genre + BPM
-  Bpm can be set as a dropdown menu: low, mid and high.
![image](https://github.com/user-attachments/assets/857d67a1-0a47-4dd5-9e13-2e79a1ab65f1)